### PR TITLE
accept dpi argument, e.g. dpi: 2 for hidpi

### DIFF
--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -38,6 +38,7 @@ function pickupNamedArguments() {
     }
 
     if(!args.width)        { args.width = 1024; }
+    if(!args.dpi)          { args.dpi = 1; }
     if(args.url)           { args.url = decodeURIComponent(args.url); }
     if(args.debug)         { debug = true; }
     if(args.resourceWait)  { resourceWait = args.resourceWait; }
@@ -80,6 +81,7 @@ function takeScreenshot() {
             phantom.exit();
         } else {
             delayScreenshotForResources();
+
             page.includeJs(
                 "https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js",
                 function() {
@@ -104,8 +106,19 @@ function takeScreenshot() {
                                });
                             },
                             page.viewportSize.width,
-                            page.viewportSize.height
+                            page.viewportSize.height / args.dpi
                         );
+                    }
+
+                    if (args.dpi !== 1) {
+                    evaluateWithArgs(
+                        function(dpi) {
+                            document.body.style.webkitTransform = "scale(" + dpi + ")";
+                            document.body.style.webkitTransformOrigin = "0% 0%";
+                            document.body.style.width = (100 / dpi) + "%";
+                        },
+                        args.dpi
+                    );
                     }
 
                     if(!foundDiv) {


### PR DESCRIPTION
Did not write a test, but it's working nicely and there's no change if you don't provide the dpi argument.
Pretty useful to screenshot cordova iphone/ipads and whatnots for app store.
Actually it's what my gems does (with the help of yours) http://github.com/nofxx/yamg
Thanks!
