### PR TITLE
ability to exit cleanly if request is taking too long

### DIFF
--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -72,7 +72,7 @@ function doRender() {
 function cutoff() {
   clearTimeout(renderTimeout);
   clearTimeout(forcedRenderTimeout);
-  console.log("Process exceeded cutoff timeout, aborting.");
+  console.log('Unable to load: ' + args.url + '. Process exceeded cutoff timeout.');
   phantom.exit();
 }
 
@@ -94,9 +94,7 @@ function evaluateWithArgs(func) {
 
 function takeScreenshot() {
   cutoffExecution();
-  console.log("before page open");
    page.open(args.url, function(status) {
-     console.log("inside page open");
         if(status !== 'success') {
             console.log('Unable to load: ' + args.url);
             phantom.exit();

--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -20,12 +20,14 @@
 var page           = new WebPage(),
     resourceWait   = 300,
     maxRenderWait  = 10000,
+    cutoffWait     = 30000,
     args           = {},
     resourceCount  = 0,
     debug          = false,
     mask           = null,
     forcedRenderTimeout,
-    renderTimeout;
+    renderTimeout,
+    cutoffTimeout;
 
 //
 // Functions
@@ -60,12 +62,27 @@ function setupMask() {
 function doRender() {
     clearTimeout(renderTimeout);
     clearTimeout(forcedRenderTimeout);
+    clearTimeout(cutoffTimeout);
     page.render(args.output);
     phantom.exit();
 }
 
+// if the page is taking too long (set via cutoffWait) to load, just exit cleanly
+function cutoff() {
+  clearTimeout(renderTimeout);
+  clearTimeout(forcedRenderTimeout);
+  console.log("Process exceeded cutoff timeout, aborting.");
+  phantom.exit();
+}
+
 function delayScreenshotForResources() {
     forcedRenderTimeout = setTimeout(doRender, maxRenderWait);
+}
+
+function cutoffExecution() {
+  if(cutoffWait != null) {
+    cutoffTimeout = setTimeout(cutoff, cutoffWait);
+  }
 }
 
 function evaluateWithArgs(func) {
@@ -75,7 +92,10 @@ function evaluateWithArgs(func) {
 }
 
 function takeScreenshot() {
+  cutoffExecution();
+  console.log("before page open");
    page.open(args.url, function(status) {
+     console.log("inside page open");
         if(status !== 'success') {
             console.log('Unable to load: ' + args.url);
             phantom.exit();

--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -10,6 +10,7 @@
 // - div           [optional] - a selector to use to screenshot to a specific element
 // - resourceWait  [optional] - default 300 - the time to wait after the last resource has loaded in MS before taking the screenshot
 // - maxRenderWait [optional] - default 10000 - the maximum time to wait before taking the screenshot, regardless of whether resources are waiting to be loaded
+// - cutoffWait    [optional] - default null - the maximum time to wait before cutting everything off and failing...this helps if there is a page taking a long time to load
 // - top, left, width, height [optional] - dimensions to use to screenshot a specific area of the screen
 //
 // == Important notice when providing height ==

--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -45,6 +45,7 @@ function pickupNamedArguments() {
     if(args.debug)         { debug = true; }
     if(args.resourceWait)  { resourceWait = args.resourceWait; }
     if(args.maxRenderWait) { maxRenderWait = args.maxRenderWait; }
+    if(args.cutoffWait)    { cutoffWait = args.cutoffWait; }
 }
 
 function setupMask() {

--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -20,7 +20,7 @@
 var page           = new WebPage(),
     resourceWait   = 300,
     maxRenderWait  = 10000,
-    cutoffWait     = 30000,
+    cutoffWait     = null,
     args           = {},
     resourceCount  = 0,
     debug          = false,

--- a/lib/screencap/version.rb
+++ b/lib/screencap/version.rb
@@ -1,3 +1,3 @@
 module Screencap
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/screencap/version.rb
+++ b/lib/screencap/version.rb
@@ -1,3 +1,3 @@
 module Screencap
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
We were having issues with certain processes taking too long when looking up a page.  While the maxRenderWait/resourceWait are available, they don't run until after the page.open call is finished, and the hang-up occurs before this.  I tested this by trying to load a page with a massive image on it.  

To solve the problem, I added another option that allows a cutoff time to be set.  If this is set, the timer is started before the page.open call, and will exit phantomjs cleanly, as well as allow Screencap to fire it's existing error for not being able to open a page.