### PR TITLE
Remove injection and dependency on jQuery

### DIFF
--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -71,10 +71,10 @@ function doRender() {
 
 // if the page is taking too long (set via cutoffWait) to load, just exit cleanly
 function cutoff() {
-  clearTimeout(renderTimeout);
-  clearTimeout(forcedRenderTimeout);
-  console.log('Unable to load: ' + args.url + '. Process exceeded cutoff timeout.');
-  phantom.exit();
+    clearTimeout(renderTimeout);
+    clearTimeout(forcedRenderTimeout);
+    console.log('Unable to load: ' + args.url + '. Process exceeded cutoff timeout.');
+    phantom.exit();
 }
 
 function delayScreenshotForResources() {
@@ -94,58 +94,54 @@ function evaluateWithArgs(func) {
 }
 
 function takeScreenshot() {
-  cutoffExecution();
-   page.open(args.url, function(status) {
+    cutoffExecution();
+    page.open(args.url, function(status) {
         if(status !== 'success') {
             console.log('Unable to load: ' + args.url);
             phantom.exit();
         } else {
+
+            var foundDiv = true;
+
+            if(args.div) {
+                var clip = evaluateWithArgs(withinPage_GetDivDimensions, args.div);
+                foundDiv = clip;
+                page.clipRect = clip;
+            } else if(mask) {
+                page.clipRect = mask;
+            } else if(args.height) {
+                // have a height resize the html & body to workaround https://github.com/ariya/phantomjs/issues/10619
+                evaluateWithArgs(
+                    function(w,h) {
+                        var els = document.querySelectorAll('html, body');
+                        for(var i = 0; i < els.length; i++) {
+                            var el = els[i];
+                            el.style.width = w + 'px';
+                            el.style.height = h + 'px';
+                            el.style.overflow = 'hidden';
+                        };
+                    },
+                    page.viewportSize.width,
+                    page.viewportSize.height / args.dpi
+                );
+            }
+
+            if (args.dpi !== 1) {
+                evaluateWithArgs(
+                    function(dpi) {
+                        document.body.style.webkitTransform = "scale(" + dpi + ")";
+                        document.body.style.webkitTransformOrigin = "0% 0%";
+                        document.body.style.width = (100 / dpi) + "%";
+                    },
+                    args.dpi
+                );
+            }
+
+            if(!foundDiv) {
+                phantom.exit();
+            }
+
             delayScreenshotForResources();
-
-            page.includeJs(
-                "https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js",
-                function() {
-
-                    var foundDiv = true;
-                    page.evaluate(function(){ jQuery.noConflict(); });
-
-                    if(args.div) {
-                        var clip = evaluateWithArgs(withinPage_GetDivDimensions, args.div);
-                        foundDiv = clip;
-                        page.clipRect = clip;
-                    } else if(mask) {
-                        page.clipRect = mask;
-                    } else if(args.height) {
-                        // have a height resize the html & body to workaround https://github.com/ariya/phantomjs/issues/10619
-                        evaluateWithArgs(
-                            function(w,h) {
-                                jQuery('body, html').css({
-                                    width: w + 'px',
-                                    height: h + 'px',
-                                    overflow: 'hidden'
-                               });
-                            },
-                            page.viewportSize.width,
-                            page.viewportSize.height / args.dpi
-                        );
-                    }
-
-                    if (args.dpi !== 1) {
-                    evaluateWithArgs(
-                        function(dpi) {
-                            document.body.style.webkitTransform = "scale(" + dpi + ")";
-                            document.body.style.webkitTransformOrigin = "0% 0%";
-                            document.body.style.width = (100 / dpi) + "%";
-                        },
-                        args.dpi
-                    );
-                    }
-
-                    if(!foundDiv) {
-                        phantom.exit();
-                    }
-                }
-            );
         }
     });
 }
@@ -154,18 +150,14 @@ function takeScreenshot() {
 // Functions evaluated within the page context
 //
 function withinPage_GetDivDimensions(div){
-    var $el = jQuery(div);
-
-    if($el.length === 0){
+    var el = document.querySelector(div);
+    if(el === null) {
         console.log(div + ' was not found. exiting');
         return false;
     }
 
-    var dims    = $el.offset();
-    dims.height = $el.height();
-    dims.width  = $el.width();
-    return dims;
-}
+    return el.getBoundingClientRect();
+};
 
 //
 // Event handlers
@@ -210,8 +202,8 @@ setupMask();
 console.log(JSON.stringify(args));
 
 if( !args.url || !args.output ) {
-	console.log('Usage: raster.js url=URL output=filename width=width[optional] height=height[optional] debug=true/false[optional] (div=div[optional] OR top=top left=left width=width height=height)');
-	phantom.exit();
+    console.log('Usage: raster.js url=URL output=filename width=width[optional] height=height[optional] debug=true/false[optional] (div=div[optional] OR top=top left=left width=width height=height)');
+    phantom.exit();
 }
 
 page.viewportSize = { width: args.width, height: args.height || 1024 };

--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -194,6 +194,11 @@ page.onResourceReceived = function(res) {
             renderTimeout = setTimeout(doRender, resourceWait);
         }
     }
+
+    if(res.url === args.url && res.status !== 200) {
+        console.log('Unable to load: ' + args.url);
+        phantom.exit();
+    }
 };
 
 //
@@ -205,8 +210,8 @@ setupMask();
 console.log(JSON.stringify(args));
 
 if( !args.url || !args.output ) {
-    console.log('Usage: raster.js url=URL output=filename width=width[optional] height=height[optional] debug=true/false[optional] (div=div[optional] OR top=top left=left width=width height=height)');
-    phantom.exit();
+	console.log('Usage: raster.js url=URL output=filename width=width[optional] height=height[optional] debug=true/false[optional] (div=div[optional] OR top=top left=left width=width height=height)');
+	phantom.exit();
 }
 
 page.viewportSize = { width: args.width, height: args.height || 1024 };

--- a/lib/screencap/version.rb
+++ b/lib/screencap/version.rb
@@ -1,3 +1,3 @@
 module Screencap
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -6,7 +6,7 @@ describe Screencap::Fetcher do
   end
 
   it 'supports a custom filename' do
-    screenshot = Screencap::Fetcher.new('http://yahoo.com').fetch(:output => TMP_DIRECTORY + 'custom_filename.png')
+    screenshot = Screencap::Fetcher.new('http://stackoverflow.com').fetch(:output => TMP_DIRECTORY + 'custom_filename.png')
     File.exists?(screenshot).should == true
   end
 
@@ -22,8 +22,9 @@ describe Screencap::Fetcher do
   end
 
   it 'captures a given element' do
-    screenshot = Screencap::Fetcher.new('http://placehold.it').fetch(:output => TMP_DIRECTORY + 'given_element.jpg', :div => 'img.image')
-    FastImage.size(screenshot)[0].should == 140
+    screenshot = Screencap::Fetcher.new('http://placekitten.com').fetch(:output => TMP_DIRECTORY + 'given_element.jpg', :div => '#image-1')
+    FastImage.size(screenshot)[0].should == 200
+    FastImage.size(screenshot)[1].should == 287
   end
 
   it 'should work when given a query string with ampersand in it' do

--- a/spec/screencap_spec.rb
+++ b/spec/screencap_spec.rb
@@ -8,7 +8,7 @@ describe Screencap do
 
   it 'throws error when phantom could not load page' do
     expect {
-      Screencap::Fetcher.new('http://doesnotexistatallipromise.com/').fetch(output: TMP_DIRECTORY + 'foo.png')
-    }.to raise_error Screencap::Error, "Could not load URL http://doesnotexistatallipromise.com/"
+      Screencap::Fetcher.new('http://www.google.com/404').fetch(output: TMP_DIRECTORY + 'foo.png')
+    }.to raise_error Screencap::Error, "Could not load URL http://www.google.com/404"
   end
 end


### PR DESCRIPTION
For some reason the jQuery URL inject started not to load for me causing the callback to not run and the window to not be resized anymore. It isn't really needed for the things we were using it for so removed it and used DOM to do the same things.