### PR TITLE
Use system.args if phantom.args is undefined

### DIFF
--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -34,11 +34,22 @@ var page           = new WebPage(),
 // Functions
 //
 function pickupNamedArguments() {
-    var i, pair;
-    for(i = 0; i < phantom.args.length; i++) {
-        pair = phantom.args[i].split(/=(.*)/);
-        args[pair[0]] = pair[1];
+    var pair, scriptArgs;
+    if (typeof phantom.args != 'undefined') {
+        // phantomjs < 2.0
+        scriptArgs = phantom.args;
+    } else {
+        // phantomjs 2.0
+        var system = require('system');
+        scriptArgs = system.args;
+        // remove first arg as always script name
+        scriptArgs.shift();
     }
+
+    scriptArgs.forEach(function(arg, i) {
+        pair = arg.split(/=(.*)/);
+        args[pair[0]] = pair[1];
+    });
 
     if(!args.width)        { args.width = 1024; }
     if(!args.dpi)          { args.dpi = 1; }


### PR DESCRIPTION
In phantomjs versions > 2.0 `phantom.args` is
no longer supported, and we should use `system.args` instead.

When I installed screencap on my dev machine, it just worked, but somehow when deploying on my clients windows server it did not work. I got an error on `phantom.args` being undefined, and when looking it up, I found it is no longer used in the new versions (>2.0). We should use `system.args` instead. For me this version works on both my dev machine and windows server. 

The code should still work for lower versions as well. 