### PR TITLE
Use http location for jQuery

### DIFF
--- a/lib/screencap/raster.js
+++ b/lib/screencap/raster.js
@@ -102,8 +102,10 @@ function takeScreenshot() {
         } else {
             delayScreenshotForResources();
 
+            // https won't run the callbacks, so we're going to use http for now
+            // until we see whether it's an issue
             page.includeJs(
-                "https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js",
+                "http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js",
                 function() {
 
                     var foundDiv = true;

--- a/screencap.gemspec
+++ b/screencap.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'phantomjs.rb'
   gem.add_development_dependency 'fastimage'
-  gem.add_runtime_dependency 'phantomjs'
+  gem.add_runtime_dependency 'phantomjs', '1.9.8.0'
 end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -6,28 +6,28 @@ describe Screencap::Fetcher do
   end
 
   it 'supports a custom filename' do
-    screenshot = Screencap::Fetcher.new('http://yahoo.com').fetch(:output => TMP_DIRECTORY + 'custom_filename.png')
+    screenshot = Screencap::Fetcher.new('http://rubyonrails.org/').fetch(output: TMP_DIRECTORY + 'custom_filename.png')
     File.exists?(screenshot).should == true
   end
 
   it 'supports a custom width' do
-    screenshot = Screencap::Fetcher.new('http://google.com').fetch(:output => TMP_DIRECTORY + 'custom_width.jpg', :width => 800)
+    screenshot = Screencap::Fetcher.new('http://google.com').fetch(output: TMP_DIRECTORY + 'custom_width.jpg', width: 800)
     FastImage.size(screenshot)[0].should == 800
   end
 
   it 'supports a custom height' do
     # note using stackoverflow.com as google.com implements x-frame-options header meaning that it won't load in the object element
-    screenshot = Screencap::Fetcher.new('http://stackoverflow.com').fetch(:output => TMP_DIRECTORY + 'custom_height.jpg', :height => 600)
+    screenshot = Screencap::Fetcher.new('http://stackoverflow.com').fetch(output: TMP_DIRECTORY + 'custom_height.jpg', height: 600)
     FastImage.size(screenshot)[1].should == 600
   end
 
   it 'captures a given element' do
-    screenshot = Screencap::Fetcher.new('http://placehold.it').fetch(:output => TMP_DIRECTORY + 'given_element.jpg', :div => 'img.image')
-    FastImage.size(screenshot)[0].should == 140
+    screenshot = Screencap::Fetcher.new('http://placehold.it').fetch(output: TMP_DIRECTORY + 'given_element.jpg', div: '#content-left')
+    FastImage.size(screenshot)[0].should == 400
   end
 
   it 'should work when given a query string with ampersand in it' do
-    screenshot = Screencap::Fetcher.new('http://google.com?1=2&3=4').fetch(:output => TMP_DIRECTORY + 'ampersand.jpg', :width => 800)
+    screenshot = Screencap::Fetcher.new('http://google.com?1=2&3=4').fetch(output: TMP_DIRECTORY + 'ampersand.jpg', width: 800)
     FastImage.size(screenshot)[0].should == 800
   end
 end


### PR DESCRIPTION
I noticed that `includeJs` won't run callbacks when you're including a `https` source, therefore ignoring all options.

* using http source for jQuery (unsure of the implications at this point)
* fixed a few broken specs
* locked PhantomJs to 1.9.8.0

There are a few other pull requests that touch on this problem. This felt like the simplest thing that could possibly work.